### PR TITLE
Dont propagate log entries to higher level loggers

### DIFF
--- a/crumbs/__init__.py
+++ b/crumbs/__init__.py
@@ -33,6 +33,7 @@ except ImportError:
     from ConfigParser import NoSectionError
 
 logger = logging.getLogger(__name__)
+logger.propagate = False
 try:
     logger.addHandler(logging.NullHandler())
 except:


### PR DESCRIPTION
If modules use crumbs and also use the standard Python logging module, log messages from crumbs will propagate to the higher level logger unless propagate is disabled. IMO leaving propagate enabled is unexpected and undesirable, especially since configuration files often contain sensitive information (username, password, etc.).

As a work around I've added `logging.getLogger('crumbs').propagate = False` to the project I'm working on now.
